### PR TITLE
feat: Add 32bit support back, V8 cache support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: yarn make:install
+        run: yarn build:win
 
       - uses: actions/upload-artifact@v2
         with:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ To package for debug purpose
 $ yarn pack
 ```
 
+## :shield: Privacy
+
+This app has analytics that will track number of users only ([analytics.js](https://github.com/ryansn/winmoji/blob/master/app/helpers/analytics.js)).
+
 ## License
 
 MIT © [Ryan Chatterton](./LICENSE)

--- a/app/helpers/analytics.js
+++ b/app/helpers/analytics.js
@@ -1,0 +1,14 @@
+const ua = require('universal-analytics');
+const { v4: uuid } = require('uuid');
+const store = require('../store');
+
+const userId = store.get('userId') || uuid();
+
+store.set('userId', userId);
+
+function activateUser() {
+  const user = ua('UA-142775737-2', userId);
+  user.pageview('/').send();
+}
+
+module.exports = { activateUser };

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -1,0 +1,10 @@
+const Store = require('electron-store');
+
+const store = new Store({
+  configName: 'user-perferences',
+  defaults: {
+    windowBounds: { x: null, y: null },
+  },
+});
+
+module.exports = store;

--- a/main.js
+++ b/main.js
@@ -3,13 +3,10 @@ const isDev = require('electron-is-dev');
 const path = require('path');
 const tray = require('./tray');
 const updater = require('./updater');
-const Store = require('electron-store');
-const store = new Store({
-  configName: 'user-perferences',
-  defaults: {
-    windowBounds: { x: null, y: null },
-  },
-});
+const { activateUser } = require('./app/helpers/analytics');
+const store = require('./app/store');
+
+require('v8-compile-cache');
 
 const mainPage = path.join('file://', __dirname, '/index.html');
 
@@ -94,4 +91,6 @@ if (!lockSingleInstance) {
   app.on('before-quit', () => {
     isQuitting = true;
   });
+
+  activateUser();
 }

--- a/package.json
+++ b/package.json
@@ -12,12 +12,11 @@
     "test": "cross-env NODE_ENV=test jest",
     "coverage": "yarn && jest --coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage && exit 0",
     "start": "yarn && yarn compile && electron main.js",
-    "compile": "./node_modules/.bin/webpack --mode=production",
+    "compile": "webpack --mode=production",
     "dev": "yarn && yarn compile && electron main.js",
     "pack": "yarn compile && build --dir",
-    "make:install": "rm -rf dist && yarn compile && ./node_modules/.bin/electron-builder build --win --x64",
-    "release": "yarn make:install",
-    "makerelease": "rm -rf dist && yarn compile && ./node_modules/.bin/electron-builder build --win --x64 -p always"
+    "build:win": "electron-builder --win",
+    "release": "rm -rf dist && yarn compile && electron-builder build --win --publish always"
   },
   "dependencies": {
     "electron-is-dev": "^1.2.0",
@@ -27,6 +26,9 @@
     "fast-levenshtein": "^2.0.6",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
+    "universal-analytics": "^0.4.23",
+    "uuid": "^8.3.1",
+    "v8-compile-cache": "^2.2.0",
     "winmojilib": "^0.3.1"
   },
   "devDependencies": {
@@ -91,14 +93,32 @@
   },
   "build": {
     "appId": "com.rchatters.winmoji",
-    "copyright": "Copyright (c) 2018 rchatters",
+    "copyright": "Copyright © 2020 rchatters",
     "productName": "winMoji",
     "win": {
-      "target": "nsis",
+      "target": [
+        {
+          "target": "portable",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        },
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        }
+      ],
       "icon": "assets/icons/win/icon.ico"
     },
+    "portable": {
+      "artifactName": "winMoji-v${version}-portable.${ext}"
+    },
     "nsis": {
-      "oneClick": false
+      "artifactName": "winMoji-v${version}-setup.${ext}"
     },
     "directories": {
       "buildResources": "build"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7752,6 +7752,15 @@ unique-string@^2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
+universal-analytics@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/universal-analytics/-/universal-analytics-0.4.23.tgz#d915e676850c25c4156762471bdd7cf2eaaca8ac"
+  integrity sha512-lgMIH7XBI6OgYn1woDEmxhGdj8yDefMKg7GkWdeATAlQZFrMrNyxSkpDzY57iY0/6fdlzTbBV03OawvvzG+q7A==
+  dependencies:
+    debug "^4.1.1"
+    request "^2.88.2"
+    uuid "^3.0.0"
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -7873,17 +7882,17 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.3.2, uuid@^3.4.0:
+uuid@^3.0.0, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
 
-v8-compile-cache@^2.1.1:
+v8-compile-cache@^2.1.1, v8-compile-cache@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==


### PR DESCRIPTION
### Goal of PR
- Add back in support for 32bit 
- Allow portable
- Add V8 compile cache
- Clean up store location
- Adding analytics (to just gather user counts, will be following up when a settings page is built to turn off /on)

_note this really needs to get re-written in typescript_