### PR TITLE
Remove unnecessary apostrophe, capitalise Windows in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-Look up emoji's on windows! It's an alternative solution to using the windows onscreen keyboard or on windows 7 where this keyboard does not exist.
+Look up emojis on Windows! It's an alternative solution to using the Windows onscreen keyboard or on Windows 7 where this keyboard does not exist.
 
 🤓😎😆😐
 <br/>


### PR DESCRIPTION
Hey Ryan, thanks for the work you've done on this project.

Just making my small mark to improve the readme, the apostrophe used here isn't correct, see 'Apostrophes and plurals' at this link for example: https://www.grammarly.com/blog/apostrophe/

I also notice incorrect apostrophes on the main site https://www.winmoji.com/ in the lead (An open-source alternative to look up emoji's) and in the footer on the right (Windows and it's emojis are trademarks of Microsoft.) too, but I don't think it's open sourced / I couldn't find it to make the pull request.

Also I capitalised Windows in the readme just for consistency with the site.

### Goal of PR
Fix grammar

### Screenshots
![image](https://github.com/ryanSN/winmoji/assets/6772127/f95332d1-3423-4ffd-a711-1b8e11be5dd8)
![image](https://github.com/ryanSN/winmoji/assets/6772127/d32bf6ac-1d1f-4e34-99c8-a386f6fb7d8c)
